### PR TITLE
D-1：【請求リスト】行の見分けやすさ改善

### DIFF
--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -11,13 +11,13 @@ export default async function LatestInvoices() {
         Latest Invoices
       </h2>
       <div className="flex grow flex-col justify-between rounded-xl bg-gray-50 p-4">
-        <div className="px-6">
+        <div className="px-6 divide-y">
           {latestInvoices.map((invoice, i) => {
             return (
               <div
                 key={invoice.id}
                 className={clsx(
-                  'flex items-center justify-between py-5 px-2 border-b border-gray-300 last:border-b-0'
+                  'flex items-center justify-between py-5 px-2 border-b border-gray-300'
                 )}
               >
                 <div className="flex items-center">

--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -17,7 +17,7 @@ export default async function LatestInvoices() {
               <div
                 key={invoice.id}
                 className={clsx(
-                  'flex flex-row items-center justify-between py-4 hover:bg-gray-200'
+                  'flex flex-row items-center justify-between py-5 px-2 border-b hover:bg-gray-200'
                 )}
               >
                 <div className="flex items-center">

--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -11,7 +11,7 @@ export default async function LatestInvoices() {
         Latest Invoices
       </h2>
       <div className="flex grow flex-col justify-between rounded-xl bg-gray-50 p-4">
-        <div className="px-6 divide-y">
+        <div className="px-6 divide-y divide-gray-300">
           {latestInvoices.map((invoice, i) => {
             return (
               <div

--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -17,7 +17,7 @@ export default async function LatestInvoices() {
               <div
                 key={invoice.id}
                 className={clsx(
-                  'flex flex-row items-center justify-between py-4'
+                  'flex items-center justify-between py-5 px-2 border-b border-gray-300 last:border-b-0'
                 )}
               >
                 <div className="flex items-center">

--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -17,7 +17,7 @@ export default async function LatestInvoices() {
               <div
                 key={invoice.id}
                 className={clsx(
-                  'flex flex-row items-center justify-between py-5 px-2 border-b hover:bg-gray-200'
+                  'flex flex-row items-center justify-between py-5 px-2 hover:bg-gray-200'
                 )}
               >
                 <div className="flex items-center">

--- a/app/ui/dashboard/latest-invoices.tsx
+++ b/app/ui/dashboard/latest-invoices.tsx
@@ -17,7 +17,7 @@ export default async function LatestInvoices() {
               <div
                 key={invoice.id}
                 className={clsx(
-                  'flex items-center justify-between py-5 px-2 border-b border-gray-300'
+                  'flex flex-row items-center justify-between py-4'
                 )}
               >
                 <div className="flex items-center">


### PR DESCRIPTION
## 対応issue

Closes #6 

## 対応内容
線やパディングを追加して、行のみにくさを解消しました。

## 工夫したところ
行の縦横のパディングを追加しました。

## スクリーンショット
### Before
<img width="1154" height="166" alt="スクリーンショット 2026-03-13 113123" src="https://github.com/user-attachments/assets/6297c1bb-0d0f-4458-ae7b-5982493d65e6" />

### After
<img width="750" height="191" alt="image" src="https://github.com/user-attachments/assets/dc12a720-2e69-475c-9cb4-afb7ed6c7b51" />
